### PR TITLE
install rsa dependency for pymysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update
 
 RUN pip install --only-binary=:all: mlflow-skinny==2.6.0
 RUN pip install --no-deps --only-binary=:all: mlflow==2.6.0
-RUN pip install --only-binary=:all: pymysql==1.1.0 boto3==1.28.44 sqlalchemy alembic sqlparse flask pandas gunicorn querystring_parser
+RUN pip install --only-binary=:all: pymysql[rsa]==1.1.0 boto3==1.28.44 sqlalchemy alembic sqlparse flask pandas gunicorn querystring_parser
 
 RUN mkdir /mlflow/
 


### PR DESCRIPTION
install the rsa dependency with pymysql to get around the following exception 

" WARNING mlflow.store.db.utils: SQLAlchemy engine could not be created. The following exception is caught.
'cryptography' package is required for sha256_password or caching_sha2_password auth methods"

https://pypi.org/project/pymysql/